### PR TITLE
Add installation of go-bindata to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,13 @@ RUN set -ex && cd ~ \
   && chmod 755 dep-linux-amd64 \
   && sudo mv dep-linux-amd64 /usr/local/bin/dep
 
+# install go-bindata
+RUN set -ex && cd ~ \
+  && curl -LO https://github.com/kevinburke/go-bindata/releases/download/v3.11.0/go-bindata-linux-amd64 \
+  && [ $(sha256sum go-bindata-linux-amd64 | cut -f1 -d' ') = "fdebe82be2ea9db495c443d38e986cd438d97ec6719b2f69b35001d546da6e46" ] \
+  && chmod 755 go-bindata-linux-amd64 \
+  && sudo mv go-bindata-linux-amd64 /usr/local/bin/go-bindata
+
 # install terraform
 RUN set -ex && cd ~ \
   && curl -LO https://releases.hashicorp.com/terraform/0.11.8/terraform_0.11.8_linux_amd64.zip \

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 This is [Truss](https://truss.works/)' custom-built docker image for use with CircleCI 2.0 jobs. It includes all the [tools needed to be a primary image](https://circleci.com/docs/2.0/custom-images/#adding-required-and-custom-tools-or-files) as well as the following tools we test and deploy with:
 
 * [AWS Command Line Interface](https://aws.amazon.com/cli/)
+* [go-bindata](https://github.com/kevinburke/go-bindata)
 * [dep](https://golang.github.io/dep/)
 * [pre-commit](http://pre-commit.com/)
 * [ShellCheck](https://www.shellcheck.net/)


### PR DESCRIPTION
To be able to manage static assets in go (e.g. for an empty bill of lading form 1203), we're using go-bindata.