### PR TITLE
Updates Go to 1.11.2, stops some apt cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,11 +43,11 @@ RUN set -ex && cd ~ \
 
 # install Go
 RUN set -ex && cd ~ \
-  && curl -LO https://dl.google.com/go/go1.10.3.linux-amd64.tar.gz \
-  && [ $(sha256sum go1.10.3.linux-amd64.tar.gz | cut -f1 -d' ') = fa1b0e45d3b647c252f51f5e1204aba049cde4af177ef9f2181f43004f901035 ] \
-  && sudo tar -C /usr/local -xzf go1.10.3.linux-amd64.tar.gz \
+  && curl -LO https://dl.google.com/go/go1.11.2.linux-amd64.tar.gz \
+  && [ $(sha256sum go1.11.2.linux-amd64.tar.gz | cut -f1 -d' ') = 1dfe664fa3d8ad714bbd15a36627992effd150ddabd7523931f077b3926d736d ] \
+  && sudo tar -C /usr/local -xzf go1.11.2.linux-amd64.tar.gz \
   && sudo ln -s /usr/local/go/bin/* /usr/local/bin \
-  && rm go1.10.3.linux-amd64.tar.gz
+  && rm go1.11.2.linux-amd64.tar.gz
 
 # install dep
 RUN set -ex && cd ~ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,6 @@ RUN set -ex && cd ~ \
   && sudo apt-get -qq update \
   && sudo apt-get -qq -y install yarn \
   && : Cleanup \
-  && sudo apt-get remove --purge --auto-remove -y apt-transport-https lsb-release \
   && sudo apt-get clean \
   && sudo rm -rf /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This is [Truss](https://truss.works/)' custom-built docker image for use with Ci
 The following languages are also installed:
 
 * Python 3.6.x (container base image)
-* Go 1.10.x
+* Go 1.11.x
 * Node 10.x
 
 For more details and exact versions, see the [Dockerfile](https://github.com/trussworks/circleci-docker-primary/blob/master/Dockerfile).


### PR DESCRIPTION
Mainly this bumps the version of Go to 1.11.2

While testing on MyMove, I found that installing postgres (postgresql-client-9.6) was consistently timing out. I narrowed this down to the removal of `apt-transport-https` and `lsb-release` which was added a few commits ago, so I removed that line also.

@brainsik and I explored _not_ removing those apt packages, but it turns out this image leaves some https sources lying around, so you get caught in a situation where you can't `update` and you can't `install apt-transport-https`, so we're just removing that line for now.