### PR TITLE
Create separately tagged image for Packer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,25 +5,43 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Check for reserved branch names
+          command: |
+            if [[ $CIRCLE_BRANCH = latest || $CIRCLE_BRANCH = packer ]]; then
+              echo "Don't use a branch named 'latest' or 'packer'; these are meaningful tags."
+              exit 1
+            fi
+      - run:
           name: Login to Docker Hub
           command: docker login -u $DOCKER_USER -p $DOCKER_PASS
       - run:
-          name: Build container
+          name: Build container - latest
           command: docker build --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"`
                                 --build-arg VCS_REF=$CIRCLE_SHA1
-                                -t circleci-docker-primary .
+                                -t trussworks/circleci-docker-primary .
+      - run:
+          name: Build container - packer
+          command: cd packer &&
+                   docker build --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"`
+                                --build-arg VCS_REF=$CIRCLE_SHA1
+                                -t trussworks/circleci-docker-primary:packer .
       - run:
           name: Release container
           command: |
-            docker tag circleci-docker-primary trussworks/circleci-docker-primary:$CIRCLE_SHA1
-            docker push trussworks/circleci-docker-primary:$CIRCLE_SHA1
-            docker tag circleci-docker-primary trussworks/circleci-docker-primary:$CIRCLE_BRANCH
-            docker push trussworks/circleci-docker-primary:$CIRCLE_BRANCH
+            for tag in $CIRCLE_SHA1 $CIRCLE_BRANCH; do
+              # latest
+              docker tag  trussworks/circleci-docker-primary trussworks/circleci-docker-primary:$tag
+              docker push trussworks/circleci-docker-primary:$tag
 
+              # packer
+              docker tag  trussworks/circleci-docker-primary:packer trussworks/circleci-docker-primary:packer-$tag
+              docker push trussworks/circleci-docker-primary:packer-$tag
+            done
+
+            # default tags
             if [[ $CIRCLE_BRANCH = master ]]; then
-              # push default tag
-              docker tag circleci-docker-primary trussworks/circleci-docker-primary
               docker push trussworks/circleci-docker-primary
+              docker push trussworks/circleci-docker-primary:packer
 
               # notify microbadger to update
               # https://microbadger.com/images/trussworks/circleci-docker-primary

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,13 +62,6 @@ RUN set -ex && cd ~ \
   && chmod 755 go-bindata-linux-amd64 \
   && sudo mv go-bindata-linux-amd64 /usr/local/bin/go-bindata
 
-# install Packer
-RUN set -ex && cd ~ \
-  && curl -LO https://releases.hashicorp.com/packer/1.3.3/packer_1.3.3_linux_amd64.zip \
-  && [ $(sha256sum packer_1.3.3_linux_amd64.zip | cut -f1 -d ' ') = 2e3ea8f366d676d6572ead7e0c773158dfea0aed9c6a740c669d447bcb48d65f ] \
-  && sudo unzip -d /usr/local/bin packer_1.3.3_linux_amd64.zip \
-  && rm -f packer_1.3.3_linux_amd64.zip
-
 # install Terraform
 RUN set -ex && cd ~ \
   && curl -LO https://releases.hashicorp.com/terraform/0.11.11/terraform_0.11.11_linux_amd64.zip \

--- a/README.md
+++ b/README.md
@@ -3,26 +3,35 @@
 [![Build status](https://img.shields.io/circleci/project/github/trussworks/circleci-docker-primary/master.svg)](https://circleci.com/gh/trussworks/circleci-docker-primary/tree/master)
 [![Version](https://images.microbadger.com/badges/version/trussworks/circleci-docker-primary.svg)](https://microbadger.com/images/trussworks/circleci-docker-primary)
 
-This is [Truss](https://truss.works/)' custom-built docker image for use with CircleCI 2.0 jobs. It includes all the [tools needed to be a primary image](https://circleci.com/docs/2.0/custom-images/#adding-required-and-custom-tools-or-files) as well as the following tools we test and deploy with:
+This is [Truss](https://truss.works/)' custom-built docker image for use with CircleCI 2.0 jobs. It includes all the [tools needed to be a primary image](https://circleci.com/docs/2.0/custom-images/#adding-required-and-custom-tools-or-files) as well as additional tools we test and deploy with.
+
+The following languages are installed:
+
+* Python 3.6.x (container base image)
+* Go 1.11.x
+* Node 10.x
+
+The following tools are installed:
 
 * [AWS Command Line Interface](https://aws.amazon.com/cli/)
 * [go-bindata](https://github.com/kevinburke/go-bindata)
 * [dep](https://golang.github.io/dep/)
-* [Packer](https://packer.io/)
 * [pre-commit](http://pre-commit.com/)
 * [ShellCheck](https://www.shellcheck.net/)
 * [Terraform](https://www.terraform.io/)
 * [terraform-docs](https://github.com/segmentio/terraform-docs)
 * [Yarn](https://yarnpkg.com/)
 
-The following languages are also installed:
+For `packer` tagged images, these additional tools are installed:
 
-* Python 3.6.x (container base image)
-* Go 1.11.x
-* Node 10.x
+* [Ansible](https://pypi.org/project/ansible/)
+* [Packer](https://packer.io/)
 
-For more details and exact versions, see the [Dockerfile](https://github.com/trussworks/circleci-docker-primary/blob/master/Dockerfile).
+For more details and exact versions, see [Dockerfile](https://github.com/trussworks/circleci-docker-primary/blob/master/Dockerfile) and [packer/Dockerfile](https://github.com/trussworks/circleci-docker-primary/blob/master/packer/Dockerfile).
 
-For the latest stable image use `trussworks/circleci-docker-primary:master`.
+For the latest stable images:
 
-For static tags, use the git hash. You can find the hash in this repo, from the [MicroBadger page](https://microbadger.com/images/trussworks/circleci-docker-primary), from the [CircleCI builds page](https://circleci.com/gh/trussworks/circleci-docker-primary/tree/master), or from the [Docker Hub tags](https://hub.docker.com/r/trussworks/circleci-docker-primary/tags/) page.
+* `trussworks/circleci-docker-primary:master`
+* `trussworks/circleci-docker-primary:packer`
+
+For static tags, use tags including the git hash. You can find the hashes in this repo, from the [MicroBadger page](https://microbadger.com/images/trussworks/circleci-docker-primary), from the [CircleCI builds page](https://circleci.com/gh/trussworks/circleci-docker-primary/tree/master), or from the [Docker Hub tags](https://hub.docker.com/r/trussworks/circleci-docker-primary/tags/) page.

--- a/packer/Dockerfile
+++ b/packer/Dockerfile
@@ -1,0 +1,29 @@
+# CircleCI primary docker image to run within
+FROM trussworks/circleci-docker-primary
+
+# Build-time metadata as defined at http://label-schema.org
+ARG BUILD_DATE
+ARG VCS_REF
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name="Truss CircleCI Primary Docker Image" \
+      org.label-schema.description="Truss custom-built docker image for CircleCI 2.0 jobs. Includes all tools needed to be a \"primary container\" as well as tools we test and deploy with." \
+      org.label-schema.url="https://truss.works/" \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url="https://github.com/trussworks/circleci-docker-primary" \
+      org.label-schema.vendor="TrussWorks, Inc." \
+      org.label-schema.version=$VCS_REF \
+      org.label-schema.schema-version="1.0"
+
+# install Packer
+RUN set -ex && cd ~ \
+  && curl -LO https://releases.hashicorp.com/packer/1.3.4/packer_1.3.4_linux_amd64.zip \
+  && [ $(sha256sum packer_1.3.4_linux_amd64.zip | cut -f1 -d ' ') = 73074f4fa07fe15b5d65a694ee7afae2d1a64f0287e6b40897adee77a7afc552 ] \
+  && sudo unzip -d /usr/local/bin packer_1.3.4_linux_amd64.zip \
+  && rm -f packer_1.3.4_linux_amd64.zip
+
+# install ansible
+RUN set -ex && cd ~ \
+  && sudo pip install --no-cache-dir --disable-pip-version-check \
+     ansible==2.7.6
+
+CMD ["/bin/sh"]


### PR DESCRIPTION
With the additional requirement of Ansible for the same project that required Packer, it's really not making sense to just shove everything all our projects need onto the same primary image.

This PR creates an additional "packer" tagged version of the primary image. It uses the primary image as the base and then adds Packer and Ansible to it.

* Packer v1.3.4
* Ansible v2.7.6