### PR TITLE
Update ansible release version 

### DIFF
--- a/packer/Dockerfile
+++ b/packer/Dockerfile
@@ -24,6 +24,6 @@ RUN set -ex && cd ~ \
 # install ansible
 RUN set -ex && cd ~ \
   && sudo pip install --no-cache-dir --disable-pip-version-check \
-     ansible==2.7.6
+     ansible==2.7.7
 
 CMD ["/bin/sh"]


### PR DESCRIPTION
A future (exact date unknown) release of ansible will include a bug fix that will allow the ansible facts variable `ansible_distribution_version` to be properly set to '2', rather than '(karoo)', and provide clarity for what that variable should represent. In the case of supporting future versions of amazon linux, we will be able to handle that now with operators like ">=" rather than dealing with it in the future.

This PR updates ansible but does not include the fix mentioned above.

relevant commit: 
https://github.com/ansible/ansible/pull/51521/commits/2a70a5d2a17219f7d3b004f5adcfdf59b9e2a45e