### PR TITLE
Upgrade bash to 5.0.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,7 @@ RUN set -ex && cd ~ \
   && CFLAGS="-DSSH_SOURCE_BASHRC" sudo make install \
   && echo "/usr/local/bin/bash" | sudo tee -a /etc/shells \
   && cd ~ \
-  && rm -rf bash-5.0 \
-  && ls -alh /usr/local/bin/bash
+  && rm -rf bash-5.0
 
 # install shellcheck
 RUN set -ex && cd ~ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # CircleCI primary docker image to run within
-FROM circleci/python:3.6
+FROM circleci/python:3.6-stretch
 
 # Build-time metadata as defined at http://label-schema.org
 ARG BUILD_DATE
@@ -32,9 +32,28 @@ RUN set -ex && cd ~ \
   && sudo apt-get clean \
   && sudo rm -rf /var/lib/apt/lists/*
 
+# Update bash
+RUN set -ex && cd ~ \
+  && curl -sLO https://ftp.gnu.org/gnu/bash/bash-5.0.tar.gz \
+  && [ $(sha256sum bash-5.0.tar.gz | cut -f1 -d' ') = b4a80f2ac66170b2913efbfb9f2594f1f76c7b1afd11f799e22035d63077fb4d ] \
+  && tar xfa bash-5.0.tar.gz \
+  && cd bash-5.0 \
+  && curl -sLO https://ftp.gnu.org/gnu/bash/bash-5.0-patches/bash50-001 \
+  && [ $(sha256sum bash50-001 | cut -f1 -d' ') = f2fe9e1f0faddf14ab9bfa88d450a75e5d028fedafad23b88716bd657c737289 ] \
+  && cat bash50-001 | patch -p0  \
+  && curl -sLO https://ftp.gnu.org/gnu/bash/bash-5.0-patches/bash50-002 \
+  && [ $(sha256sum bash50-002 | cut -f1 -d' ') = 87e87d3542e598799adb3e7e01c8165bc743e136a400ed0de015845f7ff68707 ] \
+  && cat bash50-002 | patch -p0  \
+  && CFLAGS="-DSSH_SOURCE_BASHRC" ./configure --prefix=/usr/local \
+  && CFLAGS="-DSSH_SOURCE_BASHRC" sudo make install \
+  && echo "/usr/local/bin/bash" | sudo tee -a /etc/shells \
+  && cd ~ \
+  && rm -rf bash-5.0 \
+  && ls -alh /usr/local/bin/bash
+
 # install shellcheck
 RUN set -ex && cd ~ \
-  && curl -LO https://shellcheck.storage.googleapis.com/shellcheck-v0.6.0.linux.x86_64.tar.xz \
+  && curl -sLO https://shellcheck.storage.googleapis.com/shellcheck-v0.6.0.linux.x86_64.tar.xz \
   && [ $(sha256sum shellcheck-v0.6.0.linux.x86_64.tar.xz | cut -f1 -d' ') = 95c7d6e8320d285a9f026b5241f48f1c02d225a1b08908660e8b84e58e9c7dce ] \
   && tar xvfa shellcheck-v0.6.0.linux.x86_64.tar.xz \
   && sudo mv shellcheck-v0.6.0/shellcheck /usr/local/bin \
@@ -42,7 +61,7 @@ RUN set -ex && cd ~ \
 
 # install Go
 RUN set -ex && cd ~ \
-  && curl -LO https://dl.google.com/go/go1.11.5.linux-amd64.tar.gz \
+  && curl -sLO https://dl.google.com/go/go1.11.5.linux-amd64.tar.gz \
   && [ $(sha256sum go1.11.5.linux-amd64.tar.gz | cut -f1 -d' ') = ff54aafedff961eb94792487e827515da683d61a5f9482f668008832631e5d25 ] \
   && sudo tar -C /usr/local -xzf go1.11.5.linux-amd64.tar.gz \
   && sudo ln -s /usr/local/go/bin/* /usr/local/bin \
@@ -50,28 +69,28 @@ RUN set -ex && cd ~ \
 
 # install dep
 RUN set -ex && cd ~ \
-  && curl -LO https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 \
+  && curl -sLO https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 \
   && [ $(sha256sum dep-linux-amd64 | cut -f1 -d' ') = 287b08291e14f1fae8ba44374b26a2b12eb941af3497ed0ca649253e21ba2f83 ] \
   && chmod 755 dep-linux-amd64 \
   && sudo mv dep-linux-amd64 /usr/local/bin/dep
 
 # install go-bindata
 RUN set -ex && cd ~ \
-  && curl -LO https://github.com/kevinburke/go-bindata/releases/download/v3.11.0/go-bindata-linux-amd64 \
+  && curl -sLO https://github.com/kevinburke/go-bindata/releases/download/v3.11.0/go-bindata-linux-amd64 \
   && [ $(sha256sum go-bindata-linux-amd64 | cut -f1 -d' ') = fdebe82be2ea9db495c443d38e986cd438d97ec6719b2f69b35001d546da6e46 ] \
   && chmod 755 go-bindata-linux-amd64 \
   && sudo mv go-bindata-linux-amd64 /usr/local/bin/go-bindata
 
 # install Terraform
 RUN set -ex && cd ~ \
-  && curl -LO https://releases.hashicorp.com/terraform/0.11.11/terraform_0.11.11_linux_amd64.zip \
+  && curl -sLO https://releases.hashicorp.com/terraform/0.11.11/terraform_0.11.11_linux_amd64.zip \
   && [ $(sha256sum terraform_0.11.11_linux_amd64.zip | cut -f1 -d ' ') = 94504f4a67bad612b5c8e3a4b7ce6ca2772b3c1559630dfd71e9c519e3d6149c ] \
   && sudo unzip -d /usr/local/bin terraform_0.11.11_linux_amd64.zip \
   && rm -f terraform_0.11.11_linux_amd64.zip
 
 # install terraform-docs
 RUN set -ex && cd ~ \
-  && curl -LO https://github.com/segmentio/terraform-docs/releases/download/v0.6.0/terraform-docs-v0.6.0-linux-amd64 \
+  && curl -sLO https://github.com/segmentio/terraform-docs/releases/download/v0.6.0/terraform-docs-v0.6.0-linux-amd64 \
   && [ $(sha256sum terraform-docs-v0.6.0-linux-amd64 | cut -f1 -d' ') = 7863f13b4fa94f7a4cb1eac2751c427c5754ec0da7793f4a34ce5d5d477f7c4f ] \
   && chmod +x terraform-docs-v0.6.0-linux-amd64 \
   && sudo mv terraform-docs-v0.6.0-linux-amd64 /usr/local/bin/terraform-docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,12 +19,12 @@ RUN set -ex && cd ~ \
   && sudo apt-get -qq update \
   && sudo apt-get -qq -y install apt-transport-https lsb-release \
   && : Install Node 10.x \
-  && curl -sSS https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add - \
+  && curl -sS https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add - \
   && echo "deb https://deb.nodesource.com/node_10.x $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/nodesource.list \
   && sudo apt-get -qq update \
   && sudo apt-get -qq -y install nodejs \
   && : Install Yarn \
-  && curl -sSS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - \
+  && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list \
   && sudo apt-get -qq update \
   && sudo apt-get -qq -y install yarn \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,12 +19,12 @@ RUN set -ex && cd ~ \
   && sudo apt-get -qq update \
   && sudo apt-get -qq -y install apt-transport-https lsb-release \
   && : Install Node 10.x \
-  && curl -sS https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add - \
+  && curl -sSS https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add - \
   && echo "deb https://deb.nodesource.com/node_10.x $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/nodesource.list \
   && sudo apt-get -qq update \
   && sudo apt-get -qq -y install nodejs \
   && : Install Yarn \
-  && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - \
+  && curl -sSS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list \
   && sudo apt-get -qq update \
   && sudo apt-get -qq -y install yarn \
@@ -34,14 +34,14 @@ RUN set -ex && cd ~ \
 
 # Update bash
 RUN set -ex && cd ~ \
-  && curl -sLO https://ftp.gnu.org/gnu/bash/bash-5.0.tar.gz \
+  && curl -sSLO https://ftp.gnu.org/gnu/bash/bash-5.0.tar.gz \
   && [ $(sha256sum bash-5.0.tar.gz | cut -f1 -d' ') = b4a80f2ac66170b2913efbfb9f2594f1f76c7b1afd11f799e22035d63077fb4d ] \
   && tar xfa bash-5.0.tar.gz \
   && cd bash-5.0 \
-  && curl -sLO https://ftp.gnu.org/gnu/bash/bash-5.0-patches/bash50-001 \
+  && curl -sSLO https://ftp.gnu.org/gnu/bash/bash-5.0-patches/bash50-001 \
   && [ $(sha256sum bash50-001 | cut -f1 -d' ') = f2fe9e1f0faddf14ab9bfa88d450a75e5d028fedafad23b88716bd657c737289 ] \
   && cat bash50-001 | patch -p0  \
-  && curl -sLO https://ftp.gnu.org/gnu/bash/bash-5.0-patches/bash50-002 \
+  && curl -sSLO https://ftp.gnu.org/gnu/bash/bash-5.0-patches/bash50-002 \
   && [ $(sha256sum bash50-002 | cut -f1 -d' ') = 87e87d3542e598799adb3e7e01c8165bc743e136a400ed0de015845f7ff68707 ] \
   && cat bash50-002 | patch -p0  \
   && CFLAGS="-DSSH_SOURCE_BASHRC" ./configure --prefix=/usr/local \
@@ -53,7 +53,7 @@ RUN set -ex && cd ~ \
 
 # install shellcheck
 RUN set -ex && cd ~ \
-  && curl -sLO https://shellcheck.storage.googleapis.com/shellcheck-v0.6.0.linux.x86_64.tar.xz \
+  && curl -sSLO https://shellcheck.storage.googleapis.com/shellcheck-v0.6.0.linux.x86_64.tar.xz \
   && [ $(sha256sum shellcheck-v0.6.0.linux.x86_64.tar.xz | cut -f1 -d' ') = 95c7d6e8320d285a9f026b5241f48f1c02d225a1b08908660e8b84e58e9c7dce ] \
   && tar xvfa shellcheck-v0.6.0.linux.x86_64.tar.xz \
   && sudo mv shellcheck-v0.6.0/shellcheck /usr/local/bin \
@@ -61,7 +61,7 @@ RUN set -ex && cd ~ \
 
 # install Go
 RUN set -ex && cd ~ \
-  && curl -sLO https://dl.google.com/go/go1.11.5.linux-amd64.tar.gz \
+  && curl -sSLO https://dl.google.com/go/go1.11.5.linux-amd64.tar.gz \
   && [ $(sha256sum go1.11.5.linux-amd64.tar.gz | cut -f1 -d' ') = ff54aafedff961eb94792487e827515da683d61a5f9482f668008832631e5d25 ] \
   && sudo tar -C /usr/local -xzf go1.11.5.linux-amd64.tar.gz \
   && sudo ln -s /usr/local/go/bin/* /usr/local/bin \
@@ -69,28 +69,28 @@ RUN set -ex && cd ~ \
 
 # install dep
 RUN set -ex && cd ~ \
-  && curl -sLO https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 \
+  && curl -sSLO https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 \
   && [ $(sha256sum dep-linux-amd64 | cut -f1 -d' ') = 287b08291e14f1fae8ba44374b26a2b12eb941af3497ed0ca649253e21ba2f83 ] \
   && chmod 755 dep-linux-amd64 \
   && sudo mv dep-linux-amd64 /usr/local/bin/dep
 
 # install go-bindata
 RUN set -ex && cd ~ \
-  && curl -sLO https://github.com/kevinburke/go-bindata/releases/download/v3.11.0/go-bindata-linux-amd64 \
+  && curl -sSLO https://github.com/kevinburke/go-bindata/releases/download/v3.11.0/go-bindata-linux-amd64 \
   && [ $(sha256sum go-bindata-linux-amd64 | cut -f1 -d' ') = fdebe82be2ea9db495c443d38e986cd438d97ec6719b2f69b35001d546da6e46 ] \
   && chmod 755 go-bindata-linux-amd64 \
   && sudo mv go-bindata-linux-amd64 /usr/local/bin/go-bindata
 
 # install Terraform
 RUN set -ex && cd ~ \
-  && curl -sLO https://releases.hashicorp.com/terraform/0.11.11/terraform_0.11.11_linux_amd64.zip \
+  && curl -sSLO https://releases.hashicorp.com/terraform/0.11.11/terraform_0.11.11_linux_amd64.zip \
   && [ $(sha256sum terraform_0.11.11_linux_amd64.zip | cut -f1 -d ' ') = 94504f4a67bad612b5c8e3a4b7ce6ca2772b3c1559630dfd71e9c519e3d6149c ] \
   && sudo unzip -d /usr/local/bin terraform_0.11.11_linux_amd64.zip \
   && rm -f terraform_0.11.11_linux_amd64.zip
 
 # install terraform-docs
 RUN set -ex && cd ~ \
-  && curl -sLO https://github.com/segmentio/terraform-docs/releases/download/v0.6.0/terraform-docs-v0.6.0-linux-amd64 \
+  && curl -sSLO https://github.com/segmentio/terraform-docs/releases/download/v0.6.0/terraform-docs-v0.6.0-linux-amd64 \
   && [ $(sha256sum terraform-docs-v0.6.0-linux-amd64 | cut -f1 -d' ') = 7863f13b4fa94f7a4cb1eac2751c427c5754ec0da7793f4a34ce5d5d477f7c4f ] \
   && chmod +x terraform-docs-v0.6.0-linux-amd64 \
   && sudo mv terraform-docs-v0.6.0-linux-amd64 /usr/local/bin/terraform-docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,21 @@ RUN set -ex && cd ~ \
   && curl -sSLO https://ftp.gnu.org/gnu/bash/bash-5.0-patches/bash50-002 \
   && [ $(sha256sum bash50-002 | cut -f1 -d' ') = 87e87d3542e598799adb3e7e01c8165bc743e136a400ed0de015845f7ff68707 ] \
   && cat bash50-002 | patch -p0  \
+  && curl -sSLO https://ftp.gnu.org/gnu/bash/bash-5.0-patches/bash50-003 \
+  && [ $(sha256sum bash50-003 | cut -f1 -d' ') = 4eebcdc37b13793a232c5f2f498a5fcbf7da0ecb3da2059391c096db620ec85b ] \
+  && cat bash50-003 | patch -p0  \
+  && curl -sSLO https://ftp.gnu.org/gnu/bash/bash-5.0-patches/bash50-004 \
+  && [ $(sha256sum bash50-004 | cut -f1 -d' ') = 14447ad832add8ecfafdce5384badd933697b559c4688d6b9e3d36ff36c62f08 ] \
+  && cat bash50-004 | patch -p0  \
+  && curl -sSLO https://ftp.gnu.org/gnu/bash/bash-5.0-patches/bash50-005 \
+  && [ $(sha256sum bash50-005 | cut -f1 -d' ') = 5bf54dd9bd2c211d2bfb34a49e2c741f2ed5e338767e9ce9f4d41254bf9f8276 ] \
+  && cat bash50-005 | patch -p0  \
+  && curl -sSLO https://ftp.gnu.org/gnu/bash/bash-5.0-patches/bash50-006 \
+  && [ $(sha256sum bash50-006 | cut -f1 -d' ') = d68529a6ff201b6ff5915318ab12fc16b8a0ebb77fda3308303fcc1e13398420 ] \
+  && cat bash50-006 | patch -p0  \
+  && curl -sSLO https://ftp.gnu.org/gnu/bash/bash-5.0-patches/bash50-007 \
+  && [ $(sha256sum bash50-007 | cut -f1 -d' ') = 17b41e7ee3673d8887dd25992417a398677533ab8827938aa41fad70df19af9b ] \
+  && cat bash50-007 | patch -p0  \
   && CFLAGS="-DSSH_SOURCE_BASHRC" ./configure --prefix=/usr/local \
   && CFLAGS="-DSSH_SOURCE_BASHRC" sudo make install \
   && echo "/usr/local/bin/bash" | sudo tee -a /etc/shells \


### PR DESCRIPTION
Also:
- Enforce Debian Stretch (CircleCI allows the suffix `-jesse` or `-stretch` and it's not clear which one you get unless you specify. Also is better documentation about what we're using.)
- Silent curl commands (This extra output I didn't find useful)

Enforces a version of bash by using the latest that comes with Homebrew.  This means our bash scripts can be relied on to work the same in CircleCI as well as locally in the same way.

Using this for https://github.com/transcom/mymove/pull/1721

Bash References:
- https://ftp.gnu.org/gnu/bash/
- https://formulae.brew.sh/formula/bash
- https://github.com/Homebrew/homebrew-core/blob/master/Formula/bash.rb
- https://www.gnu.org/software/bash/manual/bash.pdf
- https://www.stevejenkins.com/blog/2014/09/how-to-manually-update-bash-to-patch-shellshock-bug-on-older-fedora-based-systems/

CircleCI References:
- https://circleci.com/docs/2.0/circleci-images/#best-practices