### PR TITLE
Update Go to version 1.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,11 +42,11 @@ RUN set -ex && cd ~ \
 
 # install Go
 RUN set -ex && cd ~ \
-  && curl -LO https://dl.google.com/go/go1.11.5.linux-amd64.tar.gz \
-  && [ $(sha256sum go1.11.5.linux-amd64.tar.gz | cut -f1 -d' ') = ff54aafedff961eb94792487e827515da683d61a5f9482f668008832631e5d25 ] \
-  && sudo tar -C /usr/local -xzf go1.11.5.linux-amd64.tar.gz \
+  && curl -LO https://dl.google.com/go/go1.12.linux-amd64.tar.gz \
+  && [ $(sha256sum go1.12.linux-amd64.tar.gz | cut -f1 -d' ') = 750a07fef8579ae4839458701f4df690e0b20b8bcce33b437e4df89c451b6f13 ] \
+  && sudo tar -C /usr/local -xzf go1.12.linux-amd64.tar.gz \
   && sudo ln -s /usr/local/go/bin/* /usr/local/bin \
-  && rm go1.11.5.linux-amd64.tar.gz
+  && rm go1.12.linux-amd64.tar.gz
 
 # install dep
 RUN set -ex && cd ~ \

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is [Truss](https://truss.works/)' custom-built docker image for use with Ci
 The following languages are installed:
 
 * Python 3.6.x (container base image)
-* Go 1.11.x
+* Go 1.12.x
 * Node 10.x
 
 The following tools are installed:


### PR DESCRIPTION
Updates go version to 1.12

[Release Notes](https://golang.org/doc/go1.12)