### PR TITLE
Don't fail on microbadger

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
               docker push trussworks/circleci-docker-primary
               docker push trussworks/circleci-docker-primary:packer
 
-              # notify microbadger to update
+              # notify microbadger to update but don't fail if it isn't reachable
               # https://microbadger.com/images/trussworks/circleci-docker-primary
-              curl -X POST $MICROBADGER_WEBHOOK
+              curl -X POST $MICROBADGER_WEBHOOK || true
             fi


### PR DESCRIPTION
The website for MicroBadger is down to the pipeline is failing. This change allows us to finish the pipeline without microbadger.

Question, what do we get from them?