### PR TITLE
Pin the awscli to homebrew version and add a note

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-awscli==1.16.163
+# Homebrew pins awscli to patches divisible by 10
+awscli==1.16.160
 pre-commit==1.16.1


### PR DESCRIPTION
This should update #31 per a comment by @brainsik . Pinning to homebrew version is pretty sane here.