### PR TITLE
Test that the USER is set properly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,10 @@ jobs:
                                 -t trussworks/circleci-docker-primary:packer
                                 .
       - run:
+          name: Test containers
+          command: ./test
+
+      - run:
           name: Release container
           command: |
             for tag in $CIRCLE_SHA1 $CIRCLE_BRANCH; do

--- a/test
+++ b/test
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -eu -o pipefail
+
+for tag in latest packer; do
+    echo "* Testing USER is properly set to 'circleci' on '$tag' tagged image"
+    docker run -it trussworks/circleci-docker-primary:$tag bash -xc '[[ $(whoami) = circleci ]]'
+done
+
+echo Passed.
+exit 0


### PR DESCRIPTION
Finally, some sort of test! :-) 

This one simply ensures the image is properly set to run as the `circleci` user. Got bit by this today.