### PR TITLE
Build container with cacheable layers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,20 +14,11 @@ jobs:
       - run:
           name: Login to Docker Hub
           command: docker login -u $DOCKER_USER -p $DOCKER_PASS
+
       - run:
-          name: Build container - latest
-          command: docker build --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"`
-                                --build-arg VCS_REF=$CIRCLE_SHA1
-                                -t trussworks/circleci-docker-primary
-                                -t trussworks/circleci-docker-primary:base
-                                .
-      - run:
-          name: Build container - packer
-          command: cd packer &&
-                   docker build --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"`
-                                --build-arg VCS_REF=$CIRCLE_SHA1
-                                -t trussworks/circleci-docker-primary:packer
-                                .
+          name: Build containers
+          command: ./build
+
       - run:
           name: Test containers
           command: ./test

--- a/build
+++ b/build
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -x -eu -o pipefail
+
+# bust cache for apt-get daily
+CACHE_APT=$(date '+%Y-%m-%d')
+
+# bust cache for pip when requirements.txt changes
+CACHE_PIP=$(shasum -a 256 requirements.txt | cut -f1 -d' ')
+CACHE_PIP_PACKER=$(shasum -a 256 packer/requirements.txt | cut -f1 -d' ')
+
+docker build --build-arg CACHE_APT="$CACHE_APT" \
+             --build-arg CACHE_PIP="$CACHE_PIP" \
+             -t trussworks/circleci-docker-primary \
+             -t trussworks/circleci-docker-primary:base \
+             .
+
+pushd packer
+docker build --build-arg CACHE_PIP_PACKER="$CACHE_PIP_PACKER" \
+             -t trussworks/circleci-docker-primary:packer \
+             .
+popd

--- a/packer/Dockerfile
+++ b/packer/Dockerfile
@@ -1,19 +1,5 @@
 # CircleCI primary docker image to run within
 FROM trussworks/circleci-docker-primary:base
-
-# Build-time metadata as defined at http://label-schema.org
-ARG BUILD_DATE
-ARG VCS_REF
-LABEL org.label-schema.build-date=$BUILD_DATE \
-      org.label-schema.name="Truss CircleCI Primary Docker Image" \
-      org.label-schema.description="Truss custom-built docker image for CircleCI 2.0 jobs. Includes all tools needed to be a \"primary container\" as well as tools we test and deploy with." \
-      org.label-schema.url="https://truss.works/" \
-      org.label-schema.vcs-ref=$VCS_REF \
-      org.label-schema.vcs-url="https://github.com/trussworks/circleci-docker-primary" \
-      org.label-schema.vendor="TrussWorks, Inc." \
-      org.label-schema.version=$VCS_REF \
-      org.label-schema.schema-version="1.0"
-
 # Base image uses "circleci", to avoid using `sudo` run as root user
 USER root
 
@@ -32,6 +18,7 @@ RUN set -ex && cd ~ \
   && rm -f inspec_3.9.3-1_amd64.deb
 
 # install Python packages
+ARG CACHE_PIP_PACKER
 ADD ./requirements.txt /tmp/requirements.txt
 RUN set -ex && cd ~ \
   && pip install -r /tmp/requirements.txt --no-cache-dir --disable-pip-version-check \


### PR DESCRIPTION
This removes all the old Microbadger labels and moves us to cacheble layers. Before, having a build arg at the beginning of the Dockerfile that changed on every build meant all the subsequent layers would have new hashes (i.e., it would bust the caches). Now, we save non-static steps (like apt-get and pip installs) until the end and bust those caches independently.

The `pip install` layer only busts the cache when the requirements.txt changes.

The `apt-get install` layer gets busted daily.

This _should_ mean that using new versions of the CircleCI image results in pulling much fewer layers (dependent on what actually changed).

Additionally, a `build` script was added.