### PR TITLE
Adding gawk to tf12 container due to terraform-docs issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ For `packer` tagged images, these additional tools are installed:
 * [ansible-lint](https://pypi.org/project/ansible-lint/)
 * [Packer](https://packer.io/)
 
-For `tf12` tagged images, Terraform 0.12 is installed.
+For `tf12` tagged images, Terraform 0.12 is installed, as well as gawk,
+which needs to be present for the hacked terraform-docs pre-commit hook
+to work properly.
 
 For more details and exact versions, see [Dockerfile](https://github.com/trussworks/circleci-docker-primary/blob/master/Dockerfile) and [packer/Dockerfile](https://github.com/trussworks/circleci-docker-primary/blob/master/packer/Dockerfile).
 

--- a/tf12/Dockerfile
+++ b/tf12/Dockerfile
@@ -10,4 +10,12 @@ RUN set -ex && cd ~ \
   && unzip -d /usr/local/bin -o terraform_0.12.3_linux_amd64.zip \
   && rm -f terraform_0.12.3_linux_amd64.zip
 
+# apt-get all the things
+ARG CACHE_APT
+RUN set -ex && cd ~ \
+  && apt-get -y install gawk \
+  && : Cleanup \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
 USER circleci

--- a/tf12/Dockerfile
+++ b/tf12/Dockerfile
@@ -13,6 +13,7 @@ RUN set -ex && cd ~ \
 # apt-get all the things
 ARG CACHE_APT
 RUN set -ex && cd ~ \
+  && apt-get -qq update \
   && apt-get -y install gawk \
   && : Cleanup \
   && apt-get clean \


### PR DESCRIPTION
For tf12, terraform-docs requires some awk magic to work -- unfortunately, it requires awk of a different type than is installed with debian by default. We fix that by installing the gawk package instead of mawk.