### PR TITLE
updates go version to 1.12.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,11 @@ RUN set -ex && cd ~ \
 
 # install Go
 RUN set -ex && cd ~ \
-  && curl -sSLO https://dl.google.com/go/go1.12.5.linux-amd64.tar.gz \
-  && [ $(sha256sum go1.12.5.linux-amd64.tar.gz | cut -f1 -d' ') = aea86e3c73495f205929cfebba0d63f1382c8ac59be081b6351681415f4063cf ] \
-  && tar -C /usr/local -xzf go1.12.5.linux-amd64.tar.gz \
+  && curl -sSLO https://dl.google.com/go/go1.12.9.linux-amd64.tar.gz \
+  && [ $(sha256sum go1.12.9.linux-amd64.tar.gz | cut -f1 -d' ') = ac2a6efcc1f5ec8bdc0db0a988bb1d301d64b6d61b7e8d9e42f662fbb75a2b9b ] \
+  && tar -C /usr/local -xzf go1.12.9.linux-amd64.tar.gz \
   && ln -s /usr/local/go/bin/* /usr/local/bin \
-  && rm -v go1.12.5.linux-amd64.tar.gz
+  && rm -v go1.12.9.linux-amd64.tar.gz
 
 # install go-bindata
 RUN set -ex && cd ~ \

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is [Truss](https://truss.works/)' custom-built docker image for use with Ci
 The following languages are installed:
 
 * Python 3.7.x (container base image)
-* Go 1.12.9
+* Go 1.12.x
 * Node 10.x
 
 The following tools are installed:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is [Truss](https://truss.works/)' custom-built docker image for use with Ci
 The following languages are installed:
 
 * Python 3.7.x (container base image)
-* Go 1.12.x
+* Go 1.12.9
 * Node 10.x
 
 The following tools are installed:


### PR DESCRIPTION
Updates go from 1.12.x to 1.12.9 for minor release that include two main security concerns:
1. go1.12.8 (released 2019/08/13) includes security fixes to the net/http and net/url packages. See the Go 1.12.8 milestone on our issue tracker for details.
1. go1.12.9 (released 2019/08/15) includes fixes to the linker, and the os and math/big packages. See the Go 1.12.9 milestone on our issue tracker for details.

See the [minor version notes](https://golang.org/doc/devel/release.html#go1.12.minor) for more release notes.

Verify the checksum [here](https://golang.org/dl/) - `ac2a6efcc1f5ec8bdc0db0a988bb1d301d64b6d61b7e8d9e42f662fbb75a2b9b`

