### PR TITLE
Add hub version 2.12.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,14 @@ RUN set -ex && cd ~ \
   && chmod 755 /usr/local/bin/circleci \
   && rm -vrf circleci-cli_0.1.5879_linux_amd64 circleci-cli_0.1.5879_linux_amd64.tar.gz
 
+# install hub
+RUN set -ex && cd ~ \
+ && curl -sSLO https://github.com/github/hub/releases/download/v2.12.8/hub-linux-amd64-2.12.8.tgz \
+ && [ $(sha256sum hub-linux-amd64-2.12.8.tgz | cut -f1 -d' ') = 7093adfd1218ed031e3ebc9a0dde241e0bb6e11b8218a815280cf42ddbdc19e0 ] \
+ && tar xzf hub-linux-amd64-2.12.8.tgz \
+ && hub-linux-amd64-2.12.8/install \
+ && rm -rf hub-linux-amd64-2.12.8
+
 # install pip packages
 ARG CACHE_PIP
 ADD ./requirements.txt /tmp/requirements.txt

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The following tools are installed:
 * [terraform-docs](https://github.com/segmentio/terraform-docs)
 * [Yarn](https://yarnpkg.com/)
 * [CircleCI Local CLI](https://circleci.com/docs/2.0/local-cli/)
+* [hub](https://hub.github.com/)
 
 For `tf12` tagged images, these additional tools are installed:
 


### PR DESCRIPTION
Using `hub` to automate the creation of certain PRs. In https://github.com/transcom/mymove/pull/2794 it was suggested to add it to our circleci-docker-primary.

```
$ docker run -it trussworks/circleci-docker-primary hub version
git version 2.11.0
hub version 2.12.8
```