### PR TITLE
rm config for packer folder updater

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -7,16 +7,9 @@ update_configs:
     # Apply dependencies label to PRs
     default_labels:
       - "dependencies"
-  # Keep python modules up to date in root, batching pull requests weekly
+  # Keep python modules up to date in root & 1 level below, batching pull requests weekly
   - package_manager: "python"
     directory: "/"
-    update_schedule: "weekly"
-    # Apply dependencies label to PRs
-    default_labels:
-      - "dependencies"
-  # Keep python modules up to date in packer dir, batching pull requests weekly
-  - package_manager: "python"
-    directory: "/packer"
     update_schedule: "weekly"
     # Apply dependencies label to PRs
     default_labels:


### PR DESCRIPTION
It turns out that dependabot will look at the specified dir and the dirs one level below (in this case the /packer dir), making this part of the config redundant and leading to extra PRs for the same update.