### PR TITLE
Terraform 0.12.19

### DIFF
--- a/tf12/Dockerfile
+++ b/tf12/Dockerfile
@@ -5,10 +5,10 @@ USER root
 
 # install Terraform
 RUN set -ex && cd ~ \
-  && curl -sSLO https://releases.hashicorp.com/terraform/0.12.13/terraform_0.12.13_linux_amd64.zip \
-  && [ $(sha256sum terraform_0.12.13_linux_amd64.zip | cut -f1 -d ' ') = 63f765a3f83987b67b046a9c31acff1ec9ee618990d0eab4db34eca6c0d861ec ] \
-  && unzip -d /usr/local/bin -o terraform_0.12.13_linux_amd64.zip \
-  && rm -vf terraform_0.12.13_linux_amd64.zip
+  && curl -sSLO https://releases.hashicorp.com/terraform/0.12.19/terraform_0.12.19_linux_amd64.zip \
+  && [ $(sha256sum terraform_0.12.19_linux_amd64.zip | cut -f1 -d ' ') = a549486112f5350075fb540cfd873deb970a9baf8a028a86ee7b4472fc91e167 ] \
+  && unzip -d /usr/local/bin -o terraform_0.12.19_linux_amd64.zip \
+  && rm -vf terraform_0.12.19_linux_amd64.zip
 
 # apt-get all the things
 ARG CACHE_APT


### PR DESCRIPTION
Fixes the likes of https://app.circleci.com/jobs/github/trussworks/terraform-aws-s3-private-bucket/289 caused by this https://github.com/hashicorp/go-getter/pull/227 and fixed by this https://github.com/hashicorp/terraform/releases/tag/v0.12.19