### PR TITLE
Upgrade base image to circleci/python:3.8-buster 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # CircleCI primary docker image to run within
-FROM circleci/python:3.7-stretch
+FROM circleci/python:3.8-buster
 # Base image uses "circleci", to avoid using `sudo` run as root user
 USER root
 


### PR DESCRIPTION
This is both a python upgrade and a base image upgrade. Debian Stretch only has security support through 2020 whereas [Buster](https://en.wikipedia.org/wiki/Debian_version_history#Debian_10_(Buster)) has support through 2020 and has been out since July. Additionally, several projects are moving to Python 3.8 and need the python binary to be available. 