### PR TITLE
Consolidate the sources so as to call 'apt-get update' less

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,20 +65,22 @@ RUN set -ex && cd ~ \
   && rm -vf /tmp/requirements.txt
 
 # apt-get all the things
+# Notes:
+# - Add all apt sources first
+# - Install gawk so the terraform-docs pre-commit hack works
 ARG CACHE_APT
 RUN set -ex && cd ~ \
-  && apt-get -qq update \
+  && : Install apt packages \
   && apt-get -qq -y install --no-install-recommends apt-transport-https lsb-release \
-  && : Install Node 10.x \
+  && : Add Node 10.x \
   && curl -sS https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
   && echo "deb https://deb.nodesource.com/node_10.x $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/nodesource.list \
-  && apt-get -qq -y install --no-install-recommends nodejs \
-  && : Install Yarn \
+  && : Add Yarn \
   && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
-  && apt-get -qq -y install --no-install-recommends yarn \
-  && : Install gawk so the terraform-docs pre-commit hack works \
-  && apt-get -qq -y install --no-install-recommends gawk \
+  && apt-get -qq update \
+  && : Install apt packages \
+  && apt-get -qq -y install --no-install-recommends nodejs yarn gawk \
   && : Cleanup \
   && apt-get clean \
   && rm -vrf /var/lib/apt/lists/*


### PR DESCRIPTION
I misread this code when I was making an optimization in #83 . What this changes is:

1) add all the new sources first
2) call `apt-get -qq update` only once for new sources
3) install all packages together

The important thing here is running `apt-get -qq update` *after* adding sources. But also you need to have already installed `lsb-release` before you add sources, which is why we have installed packages in two places.