### PR TITLE
terraform-docs 0.8.0 plus remove awk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,10 +35,10 @@ RUN set -ex && cd ~ \
 
 # install terraform-docs
 RUN set -ex && cd ~ \
-  && curl -sSLO https://github.com/segmentio/terraform-docs/releases/download/v0.7.0/terraform-docs-v0.7.0-linux-amd64 \
-  && [ $(sha256sum terraform-docs-v0.7.0-linux-amd64 | cut -f1 -d' ') = c5f37a9d5731c987e1d1a95bb6ec77261c483d51f659cbd9fbcabf2199fb8360 ] \
-  && chmod 755 terraform-docs-v0.7.0-linux-amd64 \
-  && mv terraform-docs-v0.7.0-linux-amd64 /usr/local/bin/terraform-docs
+  && curl -sSLO https://github.com/segmentio/terraform-docs/releases/download/v0.8.0/terraform-docs-v0.8.0-linux-amd64 \
+  && [ $(sha256sum terraform-docs-v0.8.0-linux-amd64 | cut -f1 -d' ') = 724aa705f02cb918221af9654a7ef257074aa5d4235c2796453b84fea7958691 ] \
+  && chmod 755 terraform-docs-v0.8.0-linux-amd64 \
+  && mv terraform-docs-v0.8.0-linux-amd64 /usr/local/bin/terraform-docs
 
 # install CircleCI CLI
 RUN set -ex && cd ~ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,6 @@ RUN set -ex && cd ~ \
 # apt-get all the things
 # Notes:
 # - Add all apt sources first
-# - Install gawk so the terraform-docs pre-commit hack works
 ARG CACHE_APT
 RUN set -ex && cd ~ \
   && : Install apt packages \
@@ -80,7 +79,7 @@ RUN set -ex && cd ~ \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
   && apt-get -qq update \
   && : Install apt packages \
-  && apt-get -qq -y install --no-install-recommends nodejs yarn gawk \
+  && apt-get -qq -y install --no-install-recommends nodejs yarn \
   && : Cleanup \
   && apt-get clean \
   && rm -vrf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is [Truss](https://truss.works/)' custom-built docker image for use with Ci
 
 The following languages are installed:
 
-* Python 3.7.x (container base image)
+* Python 3.8.x (container base image)
 * Go 1.13.x
 * Node 10.x
 
@@ -21,7 +21,6 @@ The following tools are installed:
 * [Yarn](https://yarnpkg.com/)
 * [CircleCI Local CLI](https://circleci.com/docs/2.0/local-cli/)
 * [hub](https://hub.github.com/)
-* [GNU awk](https://www.gnu.org/software/gawk/) (gawk) – needed so the [terraform-docs pre-commit hook](https://github.com/antonbabenko/pre-commit-terraform/) kludge can work
 
 For `tf11` tagged images, these additional tools are installed:
 


### PR DESCRIPTION
The GNU awk hack is no longer needed as terraform-docs 0.8.0 supports terraform 0.12 natively. Update also requires a pre-commit update 

See the following to test it out
https://github.com/trussworks/terraform-aws-s3-private-bucket/compare/mk-test-docs?expand=1
https://circleci.com/gh/trussworks/terraform-aws-s3-private-bucket/344