### PR TITLE
Use ARGs for versions and sha256sums

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,58 +4,72 @@ FROM circleci/python:3.8-buster
 USER root
 
 # install shellcheck
+ARG SHELLCHECK_VERSION=0.7.0
+ARG SHELLCHECK_SHA256SUM=39c501aaca6aae3f3c7fc125b3c3af779ddbe4e67e4ebdc44c2ae5cba76c847f
 RUN set -ex && cd ~ \
-  && curl -sSLO https://shellcheck.storage.googleapis.com/shellcheck-v0.7.0.linux.x86_64.tar.xz \
-  && [ $(sha512sum shellcheck-v0.7.0.linux.x86_64.tar.xz | cut -f1 -d' ') = 84e06bee3c8b8c25f46906350fb32708f4b661636c04e55bd19cdd1071265112d84906055372149678d37f09a1667019488c62a0561b81fe6a6b45ad4fae4ac0 ] \
-  && tar xvfa shellcheck-v0.7.0.linux.x86_64.tar.xz \
-  && mv shellcheck-v0.7.0/shellcheck /usr/local/bin \
-  && rm -vrf shellcheck-v0.7.0 shellcheck-v0.7.0.linux.x86_64.tar.xz
+  && curl -sSLO https://shellcheck.storage.googleapis.com/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz \
+  && [ $(sha256sum shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz | cut -f1 -d' ') = ${SHELLCHECK_SHA256SUM} ] \
+  && tar xvfa shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz \
+  && mv shellcheck-v${SHELLCHECK_VERSION}/shellcheck /usr/local/bin \
+  && rm -vrf shellcheck-v${SHELLCHECK_VERSION} shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz
 
-# install Go
+# install go
+ARG GO_VERSION=1.13.7
+ARG GO_SHA256SUM=b3dd4bd781a0271b33168e627f7f43886b4c5d1c794a4015abf34e99c6526ca3
 RUN set -ex && cd ~ \
-  && curl -sSLO https://dl.google.com/go/go1.13.7.linux-amd64.tar.gz \
-  && [ $(sha256sum go1.13.7.linux-amd64.tar.gz | cut -f1 -d' ') = b3dd4bd781a0271b33168e627f7f43886b4c5d1c794a4015abf34e99c6526ca3 ] \
-  && tar -C /usr/local -xzf go1.13.7.linux-amd64.tar.gz \
+  && curl -sSLO https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz \
+  && [ $(sha256sum go${GO_VERSION}.linux-amd64.tar.gz | cut -f1 -d' ') = ${GO_SHA256SUM} ] \
+  && tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz \
   && ln -s /usr/local/go/bin/* /usr/local/bin \
-  && rm -v go1.13.7.linux-amd64.tar.gz
+  && rm -v go${GO_VERSION}.linux-amd64.tar.gz
 
 # install go-bindata
+ARG GO_BINDATA_VERSION=3.11.0
+ARG GO_BINDATA_SHA256SUM=fdebe82be2ea9db495c443d38e986cd438d97ec6719b2f69b35001d546da6e46
 RUN set -ex && cd ~ \
-  && curl -sSLO https://github.com/kevinburke/go-bindata/releases/download/v3.11.0/go-bindata-linux-amd64 \
-  && [ $(sha256sum go-bindata-linux-amd64 | cut -f1 -d' ') = fdebe82be2ea9db495c443d38e986cd438d97ec6719b2f69b35001d546da6e46 ] \
+  && curl -sSLO https://github.com/kevinburke/go-bindata/releases/download/v${GO_BINDATA_VERSION}/go-bindata-linux-amd64 \
+  && [ $(sha256sum go-bindata-linux-amd64 | cut -f1 -d' ') = ${GO_BINDATA_SHA256SUM} ] \
   && chmod 755 go-bindata-linux-amd64 \
   && mv go-bindata-linux-amd64 /usr/local/bin/go-bindata
 
-# install Terraform
+# install terraform
+ARG TERRAFORM_VERSION=0.12.20
+ARG TERRAFORM_SHA256SUM=46bd906f8cb9bbb871905ecb23ae7344af8017d214d735fbb6d6c8e0feb20ff3
 RUN set -ex && cd ~ \
-  && curl -sSLO https://releases.hashicorp.com/terraform/0.12.20/terraform_0.12.20_linux_amd64.zip \
-  && [ $(sha256sum terraform_0.12.20_linux_amd64.zip | cut -f1 -d ' ') = 46bd906f8cb9bbb871905ecb23ae7344af8017d214d735fbb6d6c8e0feb20ff3 ] \
-  && unzip -o -d /usr/local/bin -o terraform_0.12.20_linux_amd64.zip \
-  && rm -vf terraform_0.12.20_linux_amd64.zip
+  && curl -sSLO https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
+  && [ $(sha256sum terraform_${TERRAFORM_VERSION}_linux_amd64.zip | cut -f1 -d ' ') = ${TERRAFORM_SHA256SUM} ] \
+  && unzip -o -d /usr/local/bin -o terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
+  && rm -vf terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 
 # install terraform-docs
+ARG TERRAFORM_DOCS_VERSION=0.8.0
+ARG TERRAFORM_DOCS_SHA256SUM=724aa705f02cb918221af9654a7ef257074aa5d4235c2796453b84fea7958691
 RUN set -ex && cd ~ \
-  && curl -sSLO https://github.com/segmentio/terraform-docs/releases/download/v0.8.0/terraform-docs-v0.8.0-linux-amd64 \
-  && [ $(sha256sum terraform-docs-v0.8.0-linux-amd64 | cut -f1 -d' ') = 724aa705f02cb918221af9654a7ef257074aa5d4235c2796453b84fea7958691 ] \
-  && chmod 755 terraform-docs-v0.8.0-linux-amd64 \
-  && mv terraform-docs-v0.8.0-linux-amd64 /usr/local/bin/terraform-docs
+  && curl -sSLO https://github.com/segmentio/terraform-docs/releases/download/v${TERRAFORM_DOCS_VERSION}/terraform-docs-v${TERRAFORM_DOCS_VERSION}-linux-amd64 \
+  && [ $(sha256sum terraform-docs-v${TERRAFORM_DOCS_VERSION}-linux-amd64 | cut -f1 -d' ') = ${TERRAFORM_DOCS_SHA256SUM} ] \
+  && chmod 755 terraform-docs-v${TERRAFORM_DOCS_VERSION}-linux-amd64 \
+  && mv terraform-docs-v${TERRAFORM_DOCS_VERSION}-linux-amd64 /usr/local/bin/terraform-docs
 
-# install CircleCI CLI
+# install circleci cli
+ARG CIRCLECI_CLI_VERSION=0.1.5879
+ARG CIRCLECI_CLI_SHA256SUM=f178ea62c781aec06267017404f87983c87f171fd0e66ef3737916246ae66dd6
 RUN set -ex && cd ~ \
-  && curl -sSLO https://github.com/CircleCI-Public/circleci-cli/releases/download/v0.1.5879/circleci-cli_0.1.5879_linux_amd64.tar.gz \
-  && [ $(sha256sum circleci-cli_0.1.5879_linux_amd64.tar.gz | cut -f1 -d' ') = f178ea62c781aec06267017404f87983c87f171fd0e66ef3737916246ae66dd6 ] \
-  && tar xzf circleci-cli_0.1.5879_linux_amd64.tar.gz \
-  && mv circleci-cli_0.1.5879_linux_amd64/circleci /usr/local/bin \
+  && curl -sSLO https://github.com/CircleCI-Public/circleci-cli/releases/download/v${CIRCLECI_CLI_VERSION}/circleci-cli_${CIRCLECI_CLI_VERSION}_linux_amd64.tar.gz \
+  && [ $(sha256sum circleci-cli_${CIRCLECI_CLI_VERSION}_linux_amd64.tar.gz | cut -f1 -d' ') = ${CIRCLECI_CLI_SHA256SUM} ] \
+  && tar xzf circleci-cli_${CIRCLECI_CLI_VERSION}_linux_amd64.tar.gz \
+  && mv circleci-cli_${CIRCLECI_CLI_VERSION}_linux_amd64/circleci /usr/local/bin \
   && chmod 755 /usr/local/bin/circleci \
-  && rm -vrf circleci-cli_0.1.5879_linux_amd64 circleci-cli_0.1.5879_linux_amd64.tar.gz
+  && rm -vrf circleci-cli_${CIRCLECI_CLI_VERSION}_linux_amd64 circleci-cli_${CIRCLECI_CLI_VERSION}_linux_amd64.tar.gz
 
 # install hub
+ARG HUB_VERSION=2.14.1
+ARG HUB_SHA256SUM=734733c9d807715a4ec26ccce0f9987bd19f1c3f84dd35e56451711766930ef0
 RUN set -ex && cd ~ \
-  && curl -sSLO https://github.com/github/hub/releases/download/v2.14.1/hub-linux-amd64-2.14.1.tgz \
-  && [ $(sha256sum hub-linux-amd64-2.14.1.tgz | cut -f1 -d' ') = 734733c9d807715a4ec26ccce0f9987bd19f1c3f84dd35e56451711766930ef0 ] \
-  && tar xzf hub-linux-amd64-2.14.1.tgz \
-  && hub-linux-amd64-2.14.1/install \
-  && rm -rf hub-linux-amd64-2.14.1
+  && curl -sSLO https://github.com/github/hub/releases/download/v${HUB_VERSION}/hub-linux-amd64-${HUB_VERSION}.tgz \
+  && [ $(sha256sum hub-linux-amd64-${HUB_VERSION}.tgz | cut -f1 -d' ') = ${HUB_SHA256SUM} ] \
+  && tar xzf hub-linux-amd64-${HUB_VERSION}.tgz \
+  && hub-linux-amd64-${HUB_VERSION}/install \
+  && rm -rf hub-linux-amd64-${HUB_VERSION}
 
 # install pip packages
 ARG CACHE_PIP

--- a/packer/Dockerfile
+++ b/packer/Dockerfile
@@ -3,19 +3,14 @@ FROM trussworks/circleci-docker-primary:base
 # Base image uses "circleci", to avoid using `sudo` run as root user
 USER root
 
-# install Packer
+# install packer
+ARG PACKER_VERSION=1.5.1
+ARG PACKER_SHA256SUM=3305ede8886bc3fd83ec0640fb87418cc2a702b2cb1567b48c8cb9315e80047d
 RUN set -ex && cd ~ \
-  && curl -LO https://releases.hashicorp.com/packer/1.5.1/packer_1.5.1_linux_amd64.zip \
-  && [ $(sha256sum packer_1.5.1_linux_amd64.zip | cut -f1 -d ' ') = 3305ede8886bc3fd83ec0640fb87418cc2a702b2cb1567b48c8cb9315e80047d ] \
-  && unzip -d /usr/local/bin packer_1.5.1_linux_amd64.zip \
-  && rm -vf packer_1.5.1_linux_amd64.zip
-
-# install inspec
-RUN set -ex && cd ~ \
-  && curl -LO https://packages.chef.io/files/stable/inspec/3.9.3/ubuntu/18.04/inspec_3.9.3-1_amd64.deb \
-  && [ $(sha256sum inspec_3.9.3-1_amd64.deb | cut -f1 -d ' ') = 757dd2366a3932adc5fcc9382b30d77de6cc33152585f4c9f94f8918d9d349a7 ] \
-  && dpkg -i inspec_3.9.3-1_amd64.deb \
-  && rm -vf inspec_3.9.3-1_amd64.deb
+  && curl -LO https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip \
+  && [ $(sha256sum packer_${PACKER_VERSION}_linux_amd64.zip | cut -f1 -d ' ') = ${PACKER_SHA256SUM} ] \
+  && unzip -d /usr/local/bin packer_${PACKER_VERSION}_linux_amd64.zip \
+  && rm -vf packer_${PACKER_VERSION}_linux_amd64.zip
 
 # install Python packages
 ARG CACHE_PIP_PACKER

--- a/tf11/Dockerfile
+++ b/tf11/Dockerfile
@@ -3,11 +3,13 @@ FROM trussworks/circleci-docker-primary:base
 # Base image uses "circleci", to avoid using `sudo` run as root user
 USER root
 
-# install Terraform
+# install terraform
+ARG TERRAFORM_VERSION=0.11.14
+ARG TERRAFORM_SHA256SUM=9b9a4492738c69077b079e595f5b2a9ef1bc4e8fb5596610f69a6f322a8af8dd
 RUN set -ex && cd ~ \
-  && curl -sSLO https://releases.hashicorp.com/terraform/0.11.14/terraform_0.11.14_linux_amd64.zip \
-  && [ $(sha256sum terraform_0.11.14_linux_amd64.zip | cut -f1 -d ' ') = 9b9a4492738c69077b079e595f5b2a9ef1bc4e8fb5596610f69a6f322a8af8dd ] \
-  && unzip -o -d /usr/local/bin terraform_0.11.14_linux_amd64.zip \
-  && rm -vf terraform_0.11.14_linux_amd64.zip
+  && curl -sSLO https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
+  && [ $(sha256sum terraform_${TERRAFORM_VERSION}_linux_amd64.zip | cut -f1 -d ' ') = ${TERRAFORM_SHA256SUM} ] \
+  && unzip -o -d /usr/local/bin terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
+  && rm -vf terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 
 USER circleci


### PR DESCRIPTION
Slight simplification to the version and checksums by defining them as ARGS. 