### PR TITLE
Updates go version to 1.15.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,8 @@ RUN set -ex && cd ~ \
   && rm -vrf shellcheck-v${SHELLCHECK_VERSION} shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz
 
 # install go
-ARG GO_VERSION=1.15
-ARG GO_SHA256SUM=2d75848ac606061efe52a8068d0e647b35ce487a15bb52272c427df485193602
+ARG GO_VERSION=1.15.5
+ARG GO_SHA256SUM=9a58494e8da722c3aef248c9227b0e9c528c7318309827780f16220998180a0d
 RUN set -ex && cd ~ \
   && curl -sSLO https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz \
   && [ $(sha256sum go${GO_VERSION}.linux-amd64.tar.gz | cut -f1 -d' ') = ${GO_SHA256SUM} ] \

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is [Truss](https://truss.works/)' custom-built docker image for use with Ci
 The following languages are installed:
 
 - Python 3.8.x (container base image)
-- Go 1.14.x
+- Go 1.15.x
 - Node 10.x
 
 The following tools are installed:


### PR DESCRIPTION
Updates go from 1.15.x to 1.15.5 for minor release that include address some security concerns:
1. go1.15.3 (released 2020/10/14) includes fixes to cgo, the compiler, runtime, the go command, and the bytes, plugin, and testing packages. See the Go 1.15.3 milestone on our issue tracker for details.
1. go1.15.4 (released 2020/11/05) includes fixes to cgo, the compiler, linker, runtime, and the compress/flate, net/http, reflect, and time packages. See the Go 1.15.4 milestone on our issue tracker for details.
1. go1.15.5 (released 2020/11/12) includes security fixes to the cmd/go and math/big packages. See the Go 1.15.5 milestone on our issue tracker for details.

See the [version notes](https://golang.org/doc/devel/release.html) for more release notes.

Verify the checksum [here](https://golang.org/dl/) - `9a58494e8da722c3aef248c9227b0e9c528c7318309827780f16220998180a0d `

