### PR TITLE
Updating to tf 0.14 and deprecating 0.12, adding tfsec

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,8 @@ RUN set -ex && cd ~ \
   && mv go-bindata-linux-amd64 /usr/local/bin/go-bindata
 
 # install terraform
-ARG TERRAFORM_VERSION=0.12.29
-ARG TERRAFORM_SHA256SUM=872245d9c6302b24dc0d98a1e010aef1e4ef60865a2d1f60102c8ad03e9d5a1d
+ARG TERRAFORM_VERSION=0.14.6
+ARG TERRAFORM_SHA256SUM=63a5a45edde435fa3f278c86ce96346ee7f6b204ea949734f26f963b7dbc1074
 RUN set -ex && cd ~ \
   && curl -sSLO https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
   && [ $(sha256sum terraform_${TERRAFORM_VERSION}_linux_amd64.zip | cut -f1 -d ' ') = ${TERRAFORM_SHA256SUM} ] \
@@ -49,13 +49,23 @@ RUN set -ex && cd ~ \
   && rm -vf terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 
 # install terraform-docs
-ARG TERRAFORM_DOCS_VERSION=0.9.1
-ARG TERRAFORM_DOCS_SHA256SUM=ceb4e7f291d43a5f7672f7ca9543075554bacd02cf850e6402e74f18fbf28f7e
+ARG TERRAFORM_DOCS_VERSION=0.11.0
+ARG TERRAFORM_DOCS_SHA256SUM=8e00ae5b2e3094127d6d52f51527534994e5a4173759bb351d90c91c81823d65
 RUN set -ex && cd ~ \
-  && curl -sSLO https://github.com/segmentio/terraform-docs/releases/download/v${TERRAFORM_DOCS_VERSION}/terraform-docs-v${TERRAFORM_DOCS_VERSION}-linux-amd64 \
+  && curl -sSLO https://github.com/terraform-docs/terraform-docs/releases/download/v${TERRAFORM_DOCS_VERSION}/terraform-docs-v${TERRAFORM_DOCS_VERSION}-linux-amd64 \
   && [ $(sha256sum terraform-docs-v${TERRAFORM_DOCS_VERSION}-linux-amd64 | cut -f1 -d' ') = ${TERRAFORM_DOCS_SHA256SUM} ] \
   && chmod 755 terraform-docs-v${TERRAFORM_DOCS_VERSION}-linux-amd64 \
   && mv terraform-docs-v${TERRAFORM_DOCS_VERSION}-linux-amd64 /usr/local/bin/terraform-docs
+
+# install tfsec
+ARG TFSEC_VERSION=0.38.3
+# note: tfsec does not provide the SHASUM with the release, so this is obtained manually.
+ARG TFSEC_SHA256SUM=8444cf04c44bc4aa68201e7b5d68a943ba3eff7e8f42fbee9f28961204a7ebd8
+RUN set -ex && cd ~ \
+  && curl -sSLO https://github.com/tfsec/tfsec/releases/download/v${TFSEC_VERSION}/tfsec-linux-amd64 \
+  && [ $(sha256sum tfsec-linux-amd64 | cut -f1 -d' ') = ${TFSEC_SHA256SUM} ] \
+  && chmod 755 tfsec-linux-amd64 \
+  && mv tfsec-linux-amd64 /usr/local/bin/tfsec
 
 # install circleci cli
 ARG CIRCLECI_CLI_VERSION=0.1.6893
@@ -80,7 +90,7 @@ RUN set -ex && cd ~ \
 
 # install awscliv2, disable default pager (less)
 ENV AWS_PAGER=""
-ARG AWSCLI_VERSION=2.0.16
+ARG AWSCLI_VERSION=2.1.26
 COPY sigs/awscliv2_pgp.key /tmp/awscliv2_pgp.key
 RUN gpg --import /tmp/awscliv2_pgp.key
 RUN set -ex && cd ~ \

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The following tools are installed:
 - [go-bindata](https://github.com/kevinburke/go-bindata)
 - [pre-commit](http://pre-commit.com/)
 - [ShellCheck](https://www.shellcheck.net/)
-- [Terraform](https://www.terraform.io/) 0.12.x (see `tf13` for 0.13.x)
+- [Terraform](https://www.terraform.io/) 0.14.x (see `tf13` for 0.13.x)
 - [terraform-docs](https://github.com/segmentio/terraform-docs)
 - [Yarn](https://yarnpkg.com/)
 - [CircleCI Local CLI](https://circleci.com/docs/2.0/local-cli/)
@@ -29,7 +29,9 @@ For more details and exact versions, see [Dockerfile](https://github.com/trusswo
 
 ### tf13
 
-Next major release of Terraform that is currently in beta. This is meant for early testing and will eventually be merged back into the main image. See [tf13/Dockerfile](https://github.com/trussworks/circleci-docker-primary/blob/master/tf13/Dockerfile) for exact versions.
+Previous release of Terraform; this is kept for users who have not yet
+upgraded to Terraform 0.14. This will be phased out when 0.15 reaches
+full release. See [tf13/Dockerfile](https://github.com/trussworks/circleci-docker-primary/blob/master/tf13/Dockerfile) for exact versions.
 
 - [Terraform](https://www.terraform.io/) 0.13.x (overwrites Terraform 0.12.x)
 

--- a/tf13/Dockerfile
+++ b/tf13/Dockerfile
@@ -4,8 +4,8 @@ FROM trussworks/circleci-docker-primary:base
 USER root
 
 # install terraform
-ARG TERRAFORM_VERSION=0.13.0-beta1
-ARG TERRAFORM_SHA256SUM=cd867252689979ca33517b9e391fe39fceecf0b6df91450a6abb75833cbd2c7f
+ARG TERRAFORM_VERSION=0.13.6
+ARG TERRAFORM_SHA256SUM=55f2db00b05675026be9c898bdd3e8230ff0c5c78dd12d743ca38032092abfc9
 RUN set -ex && cd ~ \
   && curl -sSLO https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
   && [ $(sha256sum terraform_${TERRAFORM_VERSION}_linux_amd64.zip | cut -f1 -d ' ') = ${TERRAFORM_SHA256SUM} ] \


### PR DESCRIPTION
We haven't updated this in quite a while -- I just went straight from 0.12.29 to 0.14.6 for the default Terraform version, and I'm keeping the tf13 Dockerfile around with an updated version for folks who haven't yet upgraded.

I also took the chance to add tfsec to the container; unfortunately, they don't publish their SHA sums, so I had to get this manually.