### PR TITLE
bump ansible to 3.2.0

### DIFF
--- a/packer/requirements.txt
+++ b/packer/requirements.txt
@@ -1,2 +1,2 @@
-ansible==2.9.11
+ansible==3.2.0
 ansible-lint==5.0.7


### PR DESCRIPTION
This addresses two vulnerabilities:
* https://github.com/advisories/GHSA-m429-fhmv-c6q2
* https://github.com/advisories/GHSA-gfr2-qpxh-qj9m

It also brings Ansible in line with the latest major version.